### PR TITLE
Switch mingw-w64 to official git repo

### DIFF
--- a/scripts.d/10-mingw.sh
+++ b/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://github.com/mirror/mingw-w64.git"
-SCRIPT_COMMIT="eff726c461e09f35eeaed125a3570fa5f807f02b"
+SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
+SCRIPT_COMMIT="9df2e604ddf16765410724716a8d1887ffc61fa9"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1


### PR DESCRIPTION
The Github mirror seems to be broken, maybe switch back once it's revived.

Closes #276