### PR TITLE
Do full clone for mingw

### DIFF
--- a/scripts.d/10-mingw.sh
+++ b/scripts.d/10-mingw.sh
@@ -18,8 +18,9 @@ ffbuild_dockerfinal() {
 }
 
 ffbuild_dockerbuild() {
-    git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" mingw
+    retry-tool sh -c "rm -rf mingw && git clone '$SCRIPT_REPO' mingw"
     cd mingw
+    git checkout "$SCRIPT_COMMIT"
 
     cd mingw-w64-headers
 


### PR DESCRIPTION
SF's git server seems to be incapable of bandwidth saving single-commit clones.